### PR TITLE
change low utilization to be maximum metric, not average

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_low" {
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
   period              = var.cpu_utilization_low_period
-  statistic           = "Average"
+  statistic           = "Maximum"
   threshold           = local.thresholds["CPUUtilizationLowThreshold"]
 
   alarm_description = format(


### PR DESCRIPTION
## what

Uses the maximum value instead of the average for the low utilization alarm